### PR TITLE
Show [µL] for fees; reduce precision to 9 places

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -252,7 +252,7 @@ struct tx_details
         string fee_micro_str {"N/A"};
         string payed_for_kB_micro_str {""};
 
-        const double& lok_amount = LOK_AMOUNT(fee);
+        const double lok_amount = LOK_AMOUNT(fee);
 
         // tx size in kB
         double tx_size =  static_cast<double>(size)/1024.0;
@@ -2745,7 +2745,7 @@ show_my_outputs(string tx_hash_str,
             {"blk_height"           , tx_blk_height_str},
             {"tx_size"              , fmt::format("{:0.4f}",
                                                   static_cast<double>(txd.size) / 1024.0)},
-            {"tx_fee"               , lokeg::lok_amount_to_str(txd.fee, "{:0.12f}", true)},
+            {"tx_fee"               , lokeg::lok_amount_to_str(txd.fee, "{:0.9f}", true)},
             {"blk_timestamp"        , blk_timestamp},
             {"delta_time"           , age.first},
             {"outputs_no"           , static_cast<uint64_t>(txd.output_pub_keys.size())},
@@ -3299,7 +3299,7 @@ show_my_outputs(string tx_hash_str,
 
     context["show_inputs"]   = show_key_images;
     context["inputs_no"]     = static_cast<uint64_t>(inputs.size());
-    context["sum_mixin_lok"] = lokeg::lok_amount_to_str(sum_mixin_lok, "{:0.12f}", false);
+    context["sum_mixin_lok"] = lokeg::lok_amount_to_str(sum_mixin_lok, "{:0.9f}", false);
 
 
     uint64_t possible_spending  {0};
@@ -3332,7 +3332,7 @@ show_my_outputs(string tx_hash_str,
     }
 
     context["possible_spending"] = lokeg::lok_amount_to_str(
-            possible_spending, "{:0.12f}", false);
+            possible_spending, "{:0.9f}", false);
 
     add_css_style(context);
 
@@ -6695,9 +6695,9 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             {"blk_height"            , tx_blk_height_str},
             {"tx_blk_height"         , tx_blk_height},
             {"tx_size"               , fmt::format("{:0.4f}", tx_size)},
-            {"tx_fee"                , lokeg::lok_amount_to_str(txd.fee, "{:0.12f}", false)},
+            {"tx_fee"                , lokeg::lok_amount_to_str(txd.fee, "{:0.9f}", false)},
             {"tx_fee_micro"          , lokeg::lok_amount_to_str(txd.fee*1e6, "{:0.4f}", false)},
-            {"payed_for_kB"          , fmt::format("{:0.12f}", payed_for_kB)},
+            {"payed_for_kB"          , fmt::format("{:0.9f}", payed_for_kB)},
             {"tx_version"            , static_cast<uint64_t>(txd.version)},
             {"blk_timestamp"         , blk_timestamp},
             {"blk_timestamp_uint"    , blk.timestamp},

--- a/src/templates/block.html
+++ b/src/templates/block.html
@@ -64,7 +64,7 @@
             <tr>
                 <td>Hash</td>
                 <td>Outputs</td>
-                <td>Fee [&#181;&#x271]</td>
+                <td>Fee [µL]</td>
                 <td>In/Out</td>
                 <td>Size [kB]</td>
                 <td>Version</td>

--- a/src/templates/index2.html
+++ b/src/templates/index2.html
@@ -85,7 +85,7 @@
                 <td>Age {{age_format}}<!--(Δm)--></td>
                 <td>Size [kB]<!--(Δm)--></td>
                 <td>Transaction Hash</td>
-                <td>Fee</td>
+                <td>Fee [µL]</td>
                 <td>Outputs</td>
                 <td>In/Out/PID</td>
                 <td>TX Size [kB]</td>

--- a/src/templates/mempool.html
+++ b/src/templates/mempool.html
@@ -8,7 +8,7 @@
           <tr class="TableHeader">
               <td>Age [HH:MM:SS]</td>
               <td>Transaction Hash</td>
-              <td>Fee/Per kB</td>
+              <td>Fee/Per kB [µL]</td>
               <!--<td>outputs</td>-->
               <td>In/Out/PID</td>
               <td>TX Size [kB]</td>


### PR DESCRIPTION
This replaces one (broken HTML) '[µɱ]' with '[µL]', and adds the '[µL]' into the table headings for the block list and mempools (where the number used now seems just confusing).

It also replaces the length of various reported fee fields from Monero's 12 decimal places to Loki's 9 places.