### PR TITLE
Change human readable timestamp to use 24-hour times

### DIFF
--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1243,7 +1243,7 @@ get_human_readable_timestamp(uint64_t ts)
 
     gmtime_r(&tt, &tm);
 
-    strftime(buffer, sizeof(buffer), "%Y-%m-%d %I:%M:%S", &tm);
+    strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &tm);
 
     return std::string(buffer);
 }
@@ -1336,7 +1336,7 @@ get_human_readable_timestamp(uint64_t ts, std::string *result)
     time_t tt = ts;
     struct tm tm;
     gmtime_r(&tt, &tm);
-    strftime(buf, sizeof(buf), "%Y-%m-%d %I:%M:%S", &tm);
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
     *result = buf;
 }
 


### PR DESCRIPTION
Without an am/pm marker a 12-hour timestamp is misleading; this converts it to use a 00-23 hour instead of 01-12 (without a marker).

Fixes #19 