### PR TITLE
Fix source code link in the footer

### DIFF
--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -1,7 +1,7 @@
 <div class="Wrapper">
     <div class="TitleDivider" style="margin-top: 1em" ></div>
     <p style="margin-top:10px">
-        <a href="https://github.com/Doy-lee/onion-loki-blockchain-explorer/tree/loki">Source Code</a>
+        <a href="https://github.com/Doy-lee/onion-loki-blockchain-explorer">Source Code</a>
         | Explorer Version (api): {{git_branch_name}}-{{last_git_commit_date}}-{{last_git_commit_hash}} ({{api}})
         | Loki Version: {{loki_version_full}}
     </p>


### PR DESCRIPTION
The current link goes to the loki branch, which doesn't exist.