### PR TITLE
Misc fixes

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -6799,7 +6799,7 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             {
               crypto::public_key const &spend_key = register_.m_public_spend_keys[i];
               crypto::public_key const &view_key =  register_.m_public_view_keys[i];
-              uint32_t portion = register_.m_portions[i];
+              auto portion = register_.m_portions[i];
 
               account_public_address address = {};
               address.m_spend_public_key     = spend_key;

--- a/src/templates/service_node_detail.html
+++ b/src/templates/service_node_detail.html
@@ -17,7 +17,7 @@
 
         <tr>
             <td>Total Reserved: {{total_reserved}}</td>
-            <td>Register Height: {{register_height}}</td>
+            <td>Register Height: <a href="/block/{{register_height}}">{{register_height}}</a></td>
         </tr>
 
         <tr>


### PR DESCRIPTION
A couple more minor fixes for the block explorer:

- portions was wrong in the register metadata when viewing a tx containing a registration

- Links the block height to the registration block on the SN details page