### PR TITLE
Stake tx decoding

### DIFF
--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -99,6 +99,15 @@
         </table>
     {{/have_register_info}}
 
+    {{#have_contribution_info}}
+        <h2>Service Node Contribution</h2>
+        <div class="TitleDivider"></div>
+        <p>Service Node Public Key: {{contribution_service_node_pubkey}}</p>
+        <p>Contributor Address: {{contribution_address}}</p>
+        <p>Contribution Amount: {{contribution_amount}} LOKI</p>
+    {{/have_contribution_info}}
+
+
   <h2>Outputs</h2>
   <h4 class="Subtitle">{{outputs_no}} output(s) for total of {{outputs_lok_sum}} lok</h4>
   <div class="TitleDivider"></div>

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -936,6 +936,7 @@ decode_ringct(rct::rctSig const& rv,
         {
             case rct::RCTTypeSimple:
             case rct::RCTTypeBulletproof:
+            case rct::RCTTypeBulletproof2:
                 amount = rct::decodeRctSimple(rv,
                                               rct::sk2rct(scalar1),
                                               i,


### PR DESCRIPTION
This adds decoding and display of stake transaction details.

It also fixes a separate bug in the block explorer's ringct decoding implementation (which doesn't handle the v2 bulletproof format).

Here it is live, with a tx containing a stake:

https://loki.imaginary.stream/tx/2f0dc8d58a43706c15b45dd8fe9d308bad5854c6480e675353bd9e229375e358

(the stake amount looks small, but is correct: https://loki.imaginary.stream/search_service_node?value=decafde73094ea1683d7617930976a5c6c93247b712db924f2832dcb83b64a6b)