### PR TITLE
Heimdall updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set(LIBRARIES
         ringct
         ringct_basic
         device
+        randomx
         common
         mnemonics
         easylogging

--- a/cmake/FindLoki.cmake
+++ b/cmake/FindLoki.cmake
@@ -28,7 +28,7 @@
 # (c) 2014-2016 cpp-ethereum contributors.
 #------------------------------------------------------------------------------
 
-set(LIBS common;blocks;cryptonote_basic;cryptonote_core;multisig;
+set(LIBS common;blocks;cryptonote_basic;cryptonote_core;multisig;randomx;
 		cryptonote_protocol;daemonizer;mnemonics;epee;lmdb;device;
 		blockchain_db;ringct;wallet;cncrypto;easylogging;version;checkpoints)
 
@@ -44,7 +44,7 @@ foreach (l ${LIBS})
 	find_library(LOK_${L}_LIBRARY
 		NAMES ${l}
 		PATHS ${CMAKE_LIBRARY_PATH}
-		PATH_SUFFIXES "/src/${l}" "/src/" "/external/db_drivers/lib${l}" "/lib" "/src/crypto" "/contrib/epee/src" "/external/easylogging++/"
+		PATH_SUFFIXES "/src/${l}" "/src/" "/external/db_drivers/lib${l}" "/lib" "/src/crypto" "/contrib/epee/src" "/external/easylogging++/" "/external/randomx/"
 		NO_DEFAULT_PATH
 	)
 

--- a/src/MicroCore.cpp
+++ b/src/MicroCore.cpp
@@ -20,7 +20,7 @@ namespace lokeg
  */
 MicroCore::MicroCore():
         m_mempool(m_blockchain_storage),
-        m_blockchain_storage(m_mempool, m_service_node_list, m_deregister_vote_pool),
+        m_blockchain_storage(m_mempool, m_service_node_list),
         m_service_node_list(m_blockchain_storage)
 {
     m_device = &hw::get_device("default");

--- a/src/MicroCore.h
+++ b/src/MicroCore.h
@@ -30,7 +30,6 @@ namespace lokeg
 
         Blockchain m_blockchain_storage;
         tx_memory_pool m_mempool;
-        service_nodes::deregister_vote_pool m_deregister_vote_pool;
 
         hw::device* m_device;
 

--- a/src/loki_headers.h
+++ b/src/loki_headers.h
@@ -24,7 +24,6 @@
 #include "cryptonote_core/tx_pool.h"
 #include "cryptonote_core/blockchain.h"
 #include "cryptonote_core/service_node_list.h"
-#include "cryptonote_core/service_node_deregister.h"
 #include "cryptonote_core/service_node_quorum_cop.h"
 #include "blockchain_db/lmdb/db_lmdb.h"
 #include "device/device_default.hpp"

--- a/src/page.h
+++ b/src/page.h
@@ -933,7 +933,7 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
     uint64_t height = core_storage->get_current_blockchain_height();
 
     // number of last blocks to show
-    uint64_t no_of_last_blocks = std::min(no_blocks_on_index + 1, height);
+    uint64_t no_of_last_blocks = std::min(no_blocks_on_index, height);
 
     // initalise page tempate map with basic info about blockchain
     mstch::map context {

--- a/src/page.h
+++ b/src/page.h
@@ -591,46 +591,88 @@ time_t calculate_service_node_expiry_timestamp(uint64_t expiry_height)
     return result;
 }
 
-void generate_service_node_mapping(mstch::array *array, bool on_homepage, std::vector<COMMAND_RPC_GET_SERVICE_NODES::response::entry *> const *entries)
-{
-    static std::string end_of_queue = "End Of Queue";
-    size_t iterate_count = on_homepage ? snode_context.num_entries_on_front_page : entries->size();
-    iterate_count        = std::min(entries->size(), iterate_count);
+void set_service_node_fields(mstch::map &context, const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry &entry) {
 
-    array->reserve(iterate_count);
+    std::ostringstream num_contributors;
+    num_contributors << entry.contributors.size() << "/" << MAX_NUMBER_OF_CONTRIBUTORS;
 
-    static std::string num_contributors_str;
-    num_contributors_str.reserve(8);
-    for (size_t i = 0; i < iterate_count; ++i, num_contributors_str.clear())
-    {
-        COMMAND_RPC_GET_SERVICE_NODES::response::entry const *entry = (*entries)[i];
-        num_contributors_str += std::to_string(entry->contributors.size());
-        num_contributors_str += "/";
-        num_contributors_str += std::to_string(MAX_NUMBER_OF_CONTRIBUTORS);
+    uint64_t open_contribution_remaining = entry.staking_requirement > entry.total_reserved ? entry.staking_requirement - entry.total_reserved : 0;
+    uint64_t stake_remaining = entry.staking_requirement > entry.total_contributed ? entry.staking_requirement - entry.total_contributed : 0;
 
-        uint64_t contribution_remaining = entry->staking_requirement - entry->total_reserved;
-        int operator_cut_in_percent = portions_to_percent(entry->portions_for_operator);
+    std::string expiration_time_relative;
+    std::string expiration_time_str = make_service_node_expiry_time_str(&entry, &expiration_time_relative);
 
-        std::string expiration_time_relative;
-        std::string expiration_time_str = make_service_node_expiry_time_str(entry, &expiration_time_relative);
+    context["public_key"] = entry.service_node_pubkey;
+    context["num_contributors"] = num_contributors.str();
+    context["operator_cut"] = portions_to_percent(entry.portions_for_operator);
+    if (entry.portions_for_operator == STAKING_PORTIONS)
+        context["solo_node"] = true;
+    context["operator_address"] = entry.operator_address;
+    context["open_for_contribution"] = print_money(open_contribution_remaining);
+    if (!open_contribution_remaining && stake_remaining)
+        context["only_reserved_spots"] = true;
+    context["total_contributed"] = print_money(entry.total_contributed);
+    context["total_reserved"] = print_money(entry.total_reserved);
+    context["staking_requirement"] = print_money(entry.staking_requirement);
+    context["stake_remaining"] = print_money(stake_remaining);
+    if (!stake_remaining)
+        context["is_fully_funded"] = true;
 
-        mstch::map array_entry
-        {
-          {"public_key",                    entry->service_node_pubkey},
-          {"num_contributors",              num_contributors_str},
-          {"operator_cut",                  operator_cut_in_percent},
-          {"open_for_contribution",         print_money(contribution_remaining)},
-          {"contributed",                   print_money(entry->total_contributed)},
-          {"reserved",                      print_money(entry->total_reserved)},
-          {"staking_requirement",           print_money(entry->staking_requirement)},
-          {"last_reward_at_block",          entry->last_reward_block_height},
-          {"last_reward_at_block_tx_index", (entry->last_reward_transaction_index == UINT32_MAX) ? end_of_queue : std::to_string(entry->last_reward_transaction_index)},
-          {"expiration_date",               expiration_time_str},
-          {"expiration_time_relative",      expiration_time_relative},
-          {"last_uptime_proof",             last_uptime_proof_to_string(entry->last_uptime_proof)},
-        };
-        array->push_back(array_entry);
+    context["register_height"] = entry.registration_height;
+    context["last_reward_at_block"] = entry.last_reward_block_height;
+
+    if (entry.last_reward_transaction_index < std::numeric_limits<uint32_t>::max())
+        context["last_contribution_tx_index"] = entry.last_reward_transaction_index;
+
+    if (entry.active)
+        context["activation_height"] = entry.state_height;
+    else if (stake_remaining)
+        context["awaiting"] = true;
+    else
+        context["decommission_height"] = entry.state_height;
+
+    if (entry.requested_unlock_height > 0) {
+        context["expiration_block"] = entry.requested_unlock_height;
+        context["expiration_date"] = expiration_time_str;
+        context["expiration_time_relative"] = expiration_time_relative;
     }
+    context["last_uptime_proof"] = last_uptime_proof_to_string(entry.last_uptime_proof);
+    context["earned_downtime_blocks"] = entry.earned_downtime_blocks;
+    if (entry.earned_downtime_blocks > 0) {
+        context["credit_remaining"] = entry.earned_downtime_blocks;
+        context["earned_downtime"] = get_human_timespan(DIFFICULTY_TARGET_V2 * entry.earned_downtime_blocks);
+        if (entry.active && entry.earned_downtime_blocks < service_nodes::DECOMMISSION_MINIMUM)
+            context["earned_downtime_below_min"] = true;
+    }
+
+    auto &contributors = boost::get<mstch::array>(context.emplace("service_node_contributors", mstch::array{}).first->second);
+    for (const auto &contributor : entry.contributors)
+        contributors.push_back(mstch::map{
+                {"address",  contributor.address},
+                {"amount",   print_money(contributor.amount)},
+                {"reserved", print_money(contributor.reserved)},
+                });
+}
+
+void generate_service_node_mapping(mstch::map &context, std::string name, bool on_homepage, std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *> const &entries)
+{
+    size_t iterate_count = on_homepage ? snode_context.num_entries_on_front_page : entries.size();
+    iterate_count        = std::min(entries.size(), iterate_count);
+
+    auto &array = boost::get<mstch::array>(context.emplace(name, mstch::array()).first->second);
+    array.reserve(iterate_count);
+
+    for (size_t i = 0; i < iterate_count; ++i)
+    {
+        mstch::map array_entry;
+        set_service_node_fields(array_entry, *entries[i]);
+        array.push_back(std::move(array_entry));
+    }
+
+    context[name + "_size"] = entries.size();
+    size_t more = entries.size() - array.size();
+    if (more)
+        context[name + "_more"] = more;
 }
 
 std::string
@@ -644,58 +686,38 @@ render_service_nodes_html(bool add_header_and_footer)
       return (on_homepage) ? snode_context.html_context : snode_context.html_full_context;
     }
 
-    char const active_array_id[]   = "service_node_active_array";
-    char const awaiting_array_id[] = "service_node_awaiting_array";
-
-    mstch::map page_context;
-    page_context.emplace(active_array_id, mstch::array());
-    page_context.emplace(awaiting_array_id, mstch::array());
+    using sn_entry = cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry;
 
     // Split and sort the entries
-    std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *> unregistered;
-    std::vector<cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *> registered;
+    std::vector<sn_entry *> active, inactive, awaiting, reserved;
+    active.reserve(response.service_node_states.size());
+
+    for (auto &entry : response.service_node_states)
     {
-        registered.reserve  (response.service_node_states.size());
-        unregistered.reserve(response.service_node_states.size() * 0.5f);
-
-        for (auto &entry : response.service_node_states)
-        {
-          if (entry.total_contributed == entry.staking_requirement)
-          {
-            registered.push_back(&entry);
-          }
-          else
-          {
-            unregistered.push_back(&entry);
-          }
-        }
-
-        std::sort(unregistered.begin(), unregistered.end(),
-            [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *b) {
-            uint64_t a_remaining = a->staking_requirement - a->total_reserved;
-            uint64_t b_remaining = b->staking_requirement - b->total_reserved;
-
-            if (b_remaining == a_remaining)
-              return b->portions_for_operator < a->portions_for_operator;
-
-            return b_remaining < a_remaining;
-        });
-
-        std::stable_sort(registered.begin(), registered.end(),
-            [](const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *a, const cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response::entry *b) {
-            if (a->last_reward_block_height == b->last_reward_block_height)
-              return a->last_reward_transaction_index < b->last_reward_transaction_index;
-
-            return a->last_reward_block_height < b->last_reward_block_height;
-        });
+        if (entry.active)
+            active.push_back(&entry);
+        else if (entry.total_contributed >= entry.staking_requirement)
+            inactive.push_back(&entry);
+        else
+            awaiting.push_back(&entry);
     }
 
-    mstch::array& active_array   = boost::get<mstch::array>(page_context[active_array_id]);
-    mstch::array& awaiting_array = boost::get<mstch::array>(page_context[awaiting_array_id]);
-    generate_service_node_mapping(&awaiting_array, on_homepage, &unregistered);
-    generate_service_node_mapping(&active_array, on_homepage, &registered);
-    page_context["service_node_active_size"]   = (int) registered.size();
-    page_context["service_node_awaiting_size"] = (int) unregistered.size();
+    std::sort(active.begin(), active.end(), [](const sn_entry *a, const sn_entry *b) {
+        return std::make_tuple(a->last_reward_block_height, a->last_reward_transaction_index, a->service_node_pubkey)
+             < std::make_tuple(b->last_reward_block_height, b->last_reward_transaction_index, b->service_node_pubkey); });
+
+    std::sort(inactive.begin(), inactive.end(), [](const sn_entry *a, const sn_entry *b) {
+        return std::make_tuple(std::max(a->earned_downtime_blocks, int64_t{0}), a->state_height, a->last_uptime_proof, a->service_node_pubkey)
+             < std::make_tuple(std::max(b->earned_downtime_blocks, int64_t{0}), b->state_height, b->last_uptime_proof, b->service_node_pubkey); });
+
+    std::sort(awaiting.begin(), awaiting.end(), [](const sn_entry *a, const sn_entry *b) {
+        return std::make_tuple(a->portions_for_operator, a->staking_requirement - a->total_reserved, a->staking_requirement - a->total_contributed, a->service_node_pubkey)
+             < std::make_tuple(b->portions_for_operator, b->staking_requirement - b->total_reserved, b->staking_requirement - b->total_contributed, b->service_node_pubkey); });
+
+    mstch::map page_context;
+    generate_service_node_mapping(page_context, "service_nodes_active", on_homepage, active);
+    generate_service_node_mapping(page_context, "service_nodes_inactive", on_homepage, inactive);
+    generate_service_node_mapping(page_context, "service_nodes_awaiting", on_homepage, awaiting);
 
     if (on_homepage)
     {
@@ -747,7 +769,7 @@ std::string make_service_node_expiry_time_str(COMMAND_RPC_GET_SERVICE_NODES::res
     time_t expiry_time = calculate_service_node_expiry_timestamp(expiry_height);
     get_human_readable_timestamp(expiry_time, &result);
     if (expiry_time_relative)
-      *expiry_time_relative = std::string(get_human_time_ago(expiry_time, time(nullptr)));
+      *expiry_time_relative = get_human_time_ago(expiry_time, time(nullptr));
   }
   else
   {
@@ -811,8 +833,8 @@ render_quorum_states_html(bool add_header_and_footer)
     uint64_t block_height = core_storage->get_current_blockchain_height() - 1;
     if (on_homepage)
     {
-      if (block_height >= service_nodes::quorum_cop::REORG_SAFETY_BUFFER_IN_BLOCKS)
-        block_height -= service_nodes::quorum_cop::REORG_SAFETY_BUFFER_IN_BLOCKS;
+      if (block_height >= service_nodes::REORG_SAFETY_BUFFER_IN_BLOCKS)
+        block_height -= service_nodes::REORG_SAFETY_BUFFER_IN_BLOCKS;
       else
         block_height = 0;
     }
@@ -1139,7 +1161,7 @@ index2(uint64_t page_no = 0, bool refresh_page = false)
                 txd_map.insert({"height"    , i});
                 txd_map.insert({"blk_hash"  , blk_hash_str});
                 txd_map.insert({"age"       , age.first});
-                txd_map.insert({"is_ringct" , (tx.version > 1)});
+                txd_map.insert({"is_ringct" , tx.version >= cryptonote::txversion::v2_ringct});
                 txd_map.insert({"rct_type"  , tx.rct_signatures.type});
                 txd_map.insert({"blk_size"  , blk_size_str});
 
@@ -1408,8 +1430,8 @@ mempool(bool add_header_and_footer = false, uint64_t no_of_mempool_tx = 25)
                 {"timestamp"       , mempool_tx.timestamp_str},
                 {"age"             , age_str},
                 {"hash"            , pod_to_hex(mempool_tx.tx_hash)},
-                {"fee"             , mempool_tx.fee_micro_str},
-                {"payed_for_kB"    , mempool_tx.payed_for_kB_micro_str},
+                {"fee"             , mempool_tx.fee_str},
+                {"payed_for_kB"    , mempool_tx.payed_for_kB_str},
                 {"lok_inputs"      , mempool_tx.lok_inputs_str},
                 {"lok_outputs"     , mempool_tx.lok_outputs_str},
                 {"no_inputs"       , mempool_tx.no_inputs},
@@ -1598,7 +1620,7 @@ show_block(uint64_t _blk_height)
 
     // initalise page tempate map with basic info about blockchain
 
-    string blk_pow_hash_str = pod_to_hex(get_block_longhash(blk, _blk_height));
+    string blk_pow_hash_str = pod_to_hex(get_block_longhash(core_storage, blk, _blk_height, 0));
     uint64_t blk_difficulty = core_storage->get_db().get_block_difficulty(_blk_height);
 
     mstch::map context {
@@ -1708,78 +1730,8 @@ show_service_node(const std::string &service_node_pubkey)
       return std::string("Can't get service node pubkey or couldn't find as registered service node: " + service_node_pubkey);
     }
 
-    mstch::map page_context {};
-    COMMAND_RPC_GET_SERVICE_NODES::response::entry const *entry = &response.service_node_states[0];
-
-    // Make metadata render data
-    static std::string friendly_uptime_proof_not_received = "Not Received";
-    int operator_cut_in_percent = portions_to_percent(entry->portions_for_operator);
-
-    page_context["public_key"]           = entry->service_node_pubkey;
-    page_context["last_reward_at_block"] = entry->last_reward_block_height;
-    page_context["last_reward_at_block_tx_index"] = entry->last_reward_transaction_index;
-    page_context["total_contributed"]    = print_money(entry->total_contributed);
-    page_context["total_reserved"]       = print_money(entry->total_reserved);
-    page_context["staking_requirement"]  = print_money(entry->staking_requirement);
-    page_context["operator_cut"]         = operator_cut_in_percent;
-    page_context["operator_address"]     = entry->operator_address;
-    page_context["operator_address"]     = entry->operator_address;
-    page_context["last_uptime_proof"]    = (entry->last_uptime_proof == 0) ? friendly_uptime_proof_not_received : get_age(server_timestamp, entry->last_uptime_proof).first;
-    page_context["num_contributors"]     = (int) entry->contributors.size();
-    page_context["register_height"]      = entry->registration_height;
-
-    // Make contributor render data
-    char const service_node_contributors_array_id[] = "service_node_contributors_array";
-    page_context.emplace(service_node_contributors_array_id, mstch::array{});
-    mstch::array& contributors = boost::get<mstch::array>(page_context[service_node_contributors_array_id]);
-    for (COMMAND_RPC_GET_SERVICE_NODES::response::contributor const &contributor : entry->contributors)
-    {
-      mstch::map array_entry
-      {
-        {"address",  contributor.address},
-        {"amount",   print_money(contributor.amount)},
-        {"reserved", print_money(contributor.reserved)},
-      };
-
-      contributors.push_back(array_entry);
-    }
-
-    char const service_node_registered_text_id[] = "service_node_registered_text";
-    if (entry->total_contributed == entry->staking_requirement)
-    {
-      bool node_scheduled_for_expiry = true;
-      if (service_node_entry_is_infinite_staking(entry))
-        node_scheduled_for_expiry = (entry->requested_unlock_height > 0);
-
-      std::string str = "This service node is registered and active on the network. ";
-      if (node_scheduled_for_expiry)
-      {
-        std::string expiry_time_relative;
-        std::string expiry_time_str = make_service_node_expiry_time_str(entry, &expiry_time_relative);
-        str += "It is scheduled to expire on the ";
-        str += expiry_time_str;
-        str += " or ";
-        str += expiry_time_relative;
-      }
-      else
-      {
-        str += "The service node is staking infinitely, no unlock has been requested yet.";
-      }
-
-      page_context[service_node_registered_text_id] = str;
-    }
-    else
-    {
-      char buf[192];
-      buf[0] = 0;
-      uint64_t remaining_contribution = entry->staking_requirement - entry->total_reserved;
-
-      snprintf(buf, sizeof(buf),
-          "This service node is awaiting to be registered and has: %s loki to be contributed remaining",
-          print_money(remaining_contribution).c_str());
-
-      page_context[service_node_registered_text_id] = std::string(buf);
-    }
+    mstch::map page_context{};
+    set_service_node_fields(page_context, response.service_node_states[0]);
 
     add_css_style(page_context);
     return mstch::render(template_file["service_node_detail"], page_context);
@@ -2319,7 +2271,7 @@ show_ringmemberstx_jsonhex(string const& tx_hash_str)
     tx_json["hash"] = tx_hash_str;
     tx_json["hex"]  = tx_hex;
     tx_json["nettype"] = static_cast<size_t>(nettype);
-    tx_json["is_ringct"] = (tx.version > 1);
+    tx_json["is_ringct"] = tx.version >= cryptonote::txversion::v2_ringct;
     tx_json["rct_type"] = tx.rct_signatures.type;
 
     tx_json["_comment"] = "Just a placeholder for some comment if needed later";
@@ -2868,7 +2820,7 @@ show_my_outputs(string tx_hash_str,
         }
 
         // if mine output has RingCT, i.e., tx version is 2
-        if (mine_output && tx.version == 2)
+        if (mine_output && tx.version >= cryptonote::txversion::v2_ringct)
         {
             // cointbase txs have amounts in plain sight.
             // so use amount from ringct, only for non-coinbase txs
@@ -3168,7 +3120,7 @@ show_my_outputs(string tx_hash_str,
                 }
 
 
-                if (mine_output && mixin_tx.version == 2)
+                if (mine_output && mixin_tx.version >= cryptonote::txversion::v2_ringct)
                 {
                     // cointbase txs have amounts in plain sight.
                     // so use amount from ringct, only for non-coinbase txs
@@ -3237,11 +3189,12 @@ show_my_outputs(string tx_hash_str,
                         // in key image without spend key, so we just use all
                         // for regular/old txs there must be also a match
                         // in amounts, not only in output public keys
-                        if (mixin_tx.version < 2 && amount == in_key.amount)
+                        if (mixin_tx.version < cryptonote::txversion::v2_ringct)
                         {
-                            sum_mixin_lok += amount;
+                            if (amount == in_key.amount)
+                                sum_mixin_lok += amount;
                         }
-                        else if (mixin_tx.version == 2) // ringct
+                        else // ringct
                         {
                             sum_mixin_lok += amount;
                             ringct_amount += amount;
@@ -6010,7 +5963,7 @@ json_outputs(string tx_hash_str,
         }
 
         // if mine output has RingCT, i.e., tx version is 2
-        if (mine_output && tx.version == 2)
+        if (mine_output && tx.version >= cryptonote::txversion::v2_ringct)
         {
             // cointbase txs have amounts in plain sight.
             // so use amount from ringct, only for non-coinbase txs
@@ -6472,7 +6425,7 @@ find_our_outputs(
             }
 
             // if mine output has RingCT, i.e., tx version is 2
-            if (mine_output && tx.version == 2)
+            if (mine_output && tx.version >= cryptonote::txversion::v2_ringct)
             {
                 // cointbase txs have amounts in plain sight.
                 // so use amount from ringct, only for non-coinbase txs
@@ -6713,6 +6666,7 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             {"tx_blk_height"         , tx_blk_height},
             {"tx_size"               , fmt::format("{:0.4f}", tx_size)},
             {"tx_fee"                , lokeg::lok_amount_to_str(txd.fee, "{:0.9f}", false)},
+            {"tx_fee_short"          , lokeg::lok_amount_to_str(txd.fee, "{:0.4f}", false)},
             {"tx_fee_micro"          , lokeg::lok_amount_to_str(txd.fee*1e6, "{:0.4f}", false)},
             {"payed_for_kB"          , fmt::format("{:0.9f}", payed_for_kB)},
             {"tx_version"            , static_cast<uint64_t>(txd.version)},
@@ -6732,7 +6686,7 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             {"with_ring_signatures"  , static_cast<bool>(
                                                with_ring_signatures)},
             {"tx_json"               , tx_json},
-            {"is_ringct"             , (tx.version > 1)},
+            {"is_ringct"             , tx.version >= cryptonote::txversion::v2_ringct},
             {"rct_type"              , tx.rct_signatures.type},
             {"has_error"             , false},
             {"error_msg"             , string("")},
@@ -6742,41 +6696,49 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             {"construction_time"     , string {}},
     };
 
-    if (tx.version >= transaction::version_3_per_output_unlock_times)
+    if (tx.version >= cryptonote::txversion::v3_per_output_unlock_times)
     {
-        tx_extra_service_node_deregister   deregister;
         tx_extra_service_node_register     register_;
         cryptonote::account_public_address contributor;
-        if (tx.get_type() == cryptonote::transaction::type_deregister)
+        if (tx.type == cryptonote::txtype::state_change)
         {
-            context["have_deregister_info"] = true;
-            if (get_service_node_deregister_from_tx_extra(tx.extra, deregister))
-            {
-              context["deregister_service_node_index"]   = deregister.service_node_index;
-              context["deregister_block_height"]         = deregister.block_height;
+            // Getting the hard fork version here is a bit tricker, so just try with v12 then if it
+            // fails, try with v11 instead (to capture older deregs).  Both still give back a
+            // state_change (for the older deregs, it translates the dereg_old into a state_change
+            // deregistration transparently).
+            tx_extra_service_node_state_change state_change;
+            context["is_state_change"] = true;
+            bool new_style = get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_12_checkpointing);
+            if (new_style || get_service_node_state_change_from_tx_extra(tx.extra, state_change, cryptonote::network_version_11_infinite_staking)) {
+                context["state_change_new_style"] = new_style;
+                context["state_change_service_node_index"] = state_change.service_node_index;
+                context["state_change_block_height"] = state_change.block_height;
+                context[
+                    state_change.state == service_nodes::new_state::deregister ? "state_change_deregister" :
+                    state_change.state == service_nodes::new_state::decommission ? "state_change_decommission" :
+                    state_change.state == service_nodes::new_state::recommission ? "state_change_recommission" :
+                    state_change.state == service_nodes::new_state::ip_change_penalty ? "state_change_ip_change_penalty" :
+                    "state_change_unknown"] = true;
 
-              char const vote_array_id[] = "deregister_vote_array";
-              context.emplace(vote_array_id, mstch::array());
+                char const vote_array_id[] = "state_change_vote_array";
+                context.emplace(vote_array_id, mstch::array());
 
-              mstch::array& vote_array = boost::get<mstch::array>(context[vote_array_id]);
-              vote_array.reserve(deregister.votes.size());
+                mstch::array& vote_array = boost::get<mstch::array>(context[vote_array_id]);
+                vote_array.reserve(state_change.votes.size());
 
-              for (tx_extra_service_node_deregister::vote &vote : deregister.votes)
-              {
-                mstch::map entry
+                for (tx_extra_service_node_state_change::vote &vote : state_change.votes)
                 {
-                  {"deregister_voters_quorum_index", vote.voters_quorum_index},
-                  {"deregister_signature",           pod_to_hex(vote.signature)},
-                };
+                    mstch::map entry
+                    {
+                        {"state_change_voters_quorum_index", vote.validator_index},
+                            {"state_change_signature",           pod_to_hex(vote.signature)},
+                    };
 
-                vote_array.push_back(entry);
-              }
+                    vote_array.push_back(entry);
+                }
             }
-            else
-            {
-              static std::string unknown = "??";
-              context["deregister_service_node_index"] = unknown;
-              context["deregister_block_height"]       = unknown;
+            else {
+                context["state_change_unknown"] = std::string{"unknown"};
             }
         }
         else if (get_service_node_register_from_tx_extra(tx.extra, register_))
@@ -6791,7 +6753,7 @@ construct_tx_context(transaction tx, uint16_t with_ring_signatures = 0)
             context["register_service_node_pubkey"]   = extract_sn_pubkey(tx.extra);
             context["register_portions_for_operator"] = portions_to_percent(register_.m_portions_for_operator);
             context["register_expiration_timestamp_friendly"]  = timestamp_to_str_gm(register_.m_expiration_timestamp);
-            context["register_expiration_timestamp_relative"]  = std::string(get_human_time_ago(register_.m_expiration_timestamp, time(nullptr)));
+            context["register_expiration_timestamp_relative"]  = get_human_time_ago(register_.m_expiration_timestamp, time(nullptr));
             context["register_expiration_timestamp"]  = register_.m_expiration_timestamp;
             context["register_signature"]             = pod_to_hex(register_.m_service_node_signature);
 
@@ -7328,7 +7290,7 @@ get_tx_details(const transaction& tx,
     txd.signatures = tx.signatures;
 
     // get tx version
-    txd.version = tx.version;
+    txd.version = static_cast<std::underlying_type<cryptonote::txversion>::type>(tx.version);
 
     // get unlock time
     txd.unlock_time = tx.unlock_time;

--- a/src/rpccalls.cpp
+++ b/src/rpccalls.cpp
@@ -21,7 +21,8 @@ rpccalls::rpccalls(string _daemon_url,
 
     m_http_client.set_server(
             daemon_url,
-            boost::optional<epee::net_utils::http::login>{});
+            boost::optional<epee::net_utils::http::login>{},
+            epee::net_utils::ssl_support_t::e_ssl_support_disabled);
 }
 
 bool

--- a/src/templates/block.html
+++ b/src/templates/block.html
@@ -73,7 +73,7 @@
                 <tr>
                     <td><a href="/tx/{{hash}}">{{hash}}</a></td>
                     <td>{{sum_outputs}}</td>
-                    <td>{{fee_micro}}</td>
+                    <td>{{fee}}</td>
                     <td>{{no_inputs}}/{{no_outputs}}</td>                    
                     <td>{{tx_size}}</td>
                     <td>{{version}}</td>

--- a/src/templates/css/style.css
+++ b/src/templates/css/style.css
@@ -196,3 +196,23 @@ div#decoded-inputs{
 input#toggle-1[type=checkbox]:checked ~ div#decoded-inputs {
     display: block;
 }
+
+.Table.metadata td {
+    text-align: left;
+}
+
+.Table.metadata label {
+    text-align: right;
+    display: inline-block;
+    width: 50%;
+}
+
+
+td.sn-more {
+    font-style: italic;
+    font-size: 125%;
+}
+
+.omg {
+    font-weight: bold;
+}

--- a/src/templates/css/style.css
+++ b/src/templates/css/style.css
@@ -213,6 +213,17 @@ td.sn-more {
     font-size: 125%;
 }
 
+p.state-change-pubkey {
+    font-size: 120%;
+}
+th.voter-signature, td.voter-signature {
+    max-width: 300px;
+}
+td.voter-signature {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .omg {
     font-weight: bold;
 }

--- a/src/templates/index2.html
+++ b/src/templates/index2.html
@@ -85,7 +85,7 @@
                 <td>Age {{age_format}}<!--(Δm)--></td>
                 <td>Size [kB]<!--(Δm)--></td>
                 <td>Transaction Hash</td>
-                <td>Fee [µL]</td>
+                <td>Fee</td>
                 <td>Outputs</td>
                 <td>In/Out/PID</td>
                 <td>TX Size [kB]</td>
@@ -96,7 +96,7 @@
                 <td>{{age}}<!--{{time_delta}}--></td>
                 <td>{{blk_size}}</td>
                 <td><a href="/tx/{{hash}}">{{hash}}</a></td>
-                <td>{{fee_micro}}</td>
+                <td>{{tx_fee_short}}</td>
                 <td>{{sum_outputs_short}}</td>
                 <td>{{no_inputs}}/{{no_outputs}}/{{pID}}</td>
                 <td>{{tx_size_short}}</td>
@@ -125,9 +125,6 @@
     </div>
 
     {{{service_node_summary}}}
-    <div class="Wrapper">
-      <p> <a class="" href="/service_nodes">Click here to see the service node list (at most only 10 are shown here)</a> </p>
-    </div>
 
     {{{quorum_state_summary}}}
     <div class="Wrapper">

--- a/src/templates/mempool.html
+++ b/src/templates/mempool.html
@@ -8,7 +8,7 @@
           <tr class="TableHeader">
               <td>Age [HH:MM:SS]</td>
               <td>Transaction Hash</td>
-              <td>Fee/Per kB [µL]</td>
+              <td>Fee/Per kB</td>
               <!--<td>outputs</td>-->
               <td>In/Out/PID</td>
               <td>TX Size [kB]</td>

--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -67,19 +67,28 @@
         <h2>Service Node IP Change Metadata</h2>
         {{/state_change_ip_change_penalty}}
         <div class="TitleDivider"></div>
+        {{#state_change_have_pubkey_info}}
+        <p class="state-change-pubkey">Service Node Public Key: <a href="/service_node/{{state_change_service_node_pubkey}}">{{state_change_service_node_pubkey}}</a></p>
+        {{/state_change_have_pubkey_info}}
         <p>Service Node Index: {{state_change_service_node_index}}</p>
         <p>Block Height: <a href="/block/{{state_change_block_height}}">{{state_change_block_height}}</a></p>
 
         <table class="Table">
             <tr class="TableHeader">
-                <td>Voters Quorum Index</td>
-                <td>Signature</td>
+                <th class="voter-index">Voters Quorum Index</th>
+                {{#state_change_have_pubkey_info}}
+                <th class="voter-pubkey">Voter Public Key</th>
+                {{/state_change_have_pubkey_info}}
+                <th class="voter-signature">Signature</th>
             </tr>
 
             {{#state_change_vote_array}}
             <tr>
-                <td>{{state_change_voters_quorum_index}}</td>
-                <td>{{state_change_signature}}</td>
+                <td class="voter-index">{{state_change_voters_quorum_index}}</td>
+                {{#state_change_have_pubkey_info}}
+                <td class="voter-pubkey"><a href="/service_node/{{state_change_voter_pubkey}}">{{state_change_voter_pubkey}}</a></td>
+                {{/state_change_have_pubkey_info}}
+                <td class="voter-signature" title="{{state_change_signature}}">{{state_change_signature}}</td>
             </tr>
             {{/state_change_vote_array}}
         </table>

--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -53,11 +53,22 @@
         </tr>
     </table>
 
-    {{#have_deregister_info}}
+    {{#is_state_change}}
+        {{#state_change_deregister}}
         <h2>Service Node Deregister Metadata</h2>
+        {{/state_change_deregister}}
+        {{#state_change_decommission}}
+        <h2>Service Node Decommission Metadata</h2>
+        {{/state_change_decommission}}
+        {{#state_change_recommission}}
+        <h2>Service Node Recommission Metadata</h2>
+        {{/state_change_recommission}}
+        {{#state_change_ip_change_penalty}}
+        <h2>Service Node IP Change Metadata</h2>
+        {{/state_change_ip_change_penalty}}
         <div class="TitleDivider"></div>
-        <p>Service Node Index: {{deregister_service_node_index}}</p>
-        <p>Block Height: {{deregister_block_height}}</p>
+        <p>Service Node Index: {{state_change_service_node_index}}</p>
+        <p>Block Height: <a href="/block/{{state_change_block_height}}">{{state_change_block_height}}</a></p>
 
         <table class="Table">
             <tr class="TableHeader">
@@ -65,14 +76,14 @@
                 <td>Signature</td>
             </tr>
 
-            {{#deregister_vote_array}}
+            {{#state_change_vote_array}}
             <tr>
-                <td>{{deregister_voters_quorum_index}}</td>
-                <td>{{deregister_signature}}</td>
+                <td>{{state_change_voters_quorum_index}}</td>
+                <td>{{state_change_signature}}</td>
             </tr>
-            {{/deregister_vote_array}}
+            {{/state_change_vote_array}}
         </table>
-    {{/have_deregister_info}}
+    {{/is_state_change}}
 
     {{#have_register_info}}
         <h2>Service Node Register Metadata</h2>

--- a/src/templates/service_node_detail.html
+++ b/src/templates/service_node_detail.html
@@ -4,30 +4,73 @@
 
     <h2>Metadata</h2>
     <div class="TitleDivider"></div>
-    <table class="Table">
+    <table class="Table metadata">
         <tr>
-            <td>Staking Requirement: {{staking_requirement}}</td>
-            <td>Last Reward At Height/Index: <a href="/block/{{last_reward_at_block}}">{{last_reward_at_block}}</a>/{{last_reward_at_block_tx_index}}</td>
+            <td><label>Staking Requirement:</label> {{staking_requirement}}</td>
+            <td><label>Registration Height:</label> <a href="/block/{{register_height}}">{{register_height}}</a></td>
         </tr>
 
         <tr>
-            <td>Total Contributed: {{total_contributed}}</td>
-            <td>Operator Cut: {{operator_cut}}%</td>
+            <td><label>Total Reserved:</label> {{total_reserved}}</td>
+            <td>
+                {{#last_contribution_tx_index}}
+                <label>Last Contribution at Height/Index:</label> <a href="/block/{{last_reward_at_block}}">{{last_reward_at_block}}</a>/{{last_contribution_tx_index}}</td>
+                {{/last_contribution_tx_index}}
+                {{^last_contribution_tx_index}}
+                <label>Last Reward At Height:</label> <a href="/block/{{last_reward_at_block}}">{{last_reward_at_block}}</a>
+                {{/last_contribution_tx_index}}
+            </td>
         </tr>
 
         <tr>
-            <td>Total Reserved: {{total_reserved}}</td>
-            <td>Register Height: <a href="/block/{{register_height}}">{{register_height}}</a></td>
+            <td><label>Total Contributed:</label> {{total_contributed}}</td>
+            <td><label>Last Uptime Proof:</label> {{last_uptime_proof}}</td>
         </tr>
 
         <tr>
-            <td></td>
-            <td>Last Uptime Proof: {{last_uptime_proof}}</td>
+            <td>{{^solo_node}}<label>Operator Fee:</label> {{operator_cut}}%{{/solo_node}}</td>
+            <td>
+                <label>Allowed downtime:</label>
+                {{#credit_remaining}}
+                    {{earned_downtime}} ({{credit_remaining}} blocks)
+                    {{#earned_downtime_below_minimum}} (Note: ≥ 60 blocks required){{/earned_downtime_below_minimum}}
+                {{/credit_remaining}}
+                {{^credit_remaining}}None{{/credit_remaining}}
+            </td>
         </tr>
     </table>
 
+    <h2>Service Node Status</h2>
     <div class="TitleDivider"></div>
-    <p style="margin: 0px"> {{service_node_registered_text}} </p>
+    {{#activation_height}}
+    <p class="sn-active">Registered, staked, and active on the network since block {{activation_height}}.</p>
+    {{/activation_height}}
+    {{#decommission_height}}
+    <p class="sn-decomm"><span class="omg">Decommissioned</span>: this service node is
+    registered and staked, but is currently <span class="omg">decommissioned</span> (since block
+    {{decommission_height}}) for failing to meet service node requirements.
+    {{#credit_remaining}}
+    If it does not return to active duty within {{credit_remaining}} blocks (about
+    {{earned_downtime}}) it will face <span class="omg">deregistration</span>.
+    {{/credit_remaining}}
+    {{^credit_remaining}}
+    The decommission time has expired; service node <span class="omg">deregistration</span> is imminent.
+    {{/credit_remaining}}
+    </p>
+    {{/decommission_height}}
+    {{#awaiting}}
+    <p class="sn-awaiting">Awaiting registration.  This service node has {{stake_remaining}}
+    LOKI remaining to be contributed.</p>
+    {{/awaiting}}
+
+    <p class="sn-expiration">
+    {{#expiration_block}}
+    This service node is scheduled to expire at block {{expiration_block}}, in approximately {{expiration_time_relative}} ({{expiration_date}} UTC, est.)
+    {{/expiration_block}}
+    {{^expiration_block}}
+    This service node is staking infinitely: no unlock has been initiated by any of its contributors.
+    {{/expiration_block}}
+    </p>
 
     <h2>{{num_contributors}} Contributor(s)</h2>
     <div class="TitleDivider"></div>
@@ -39,12 +82,12 @@
             <td>Reserved</td>
         </tr>
 
-        {{#service_node_contributors_array}}
+        {{#service_node_contributors}}
         <tr>
             <td>{{address}}</td>
             <td>{{amount}}</td>
             <td>{{reserved}}</td>
         </tr>
-        {{/service_node_contributors_array}}
+        {{/service_node_contributors}}
     </table>
 </div>

--- a/src/templates/service_nodes.html
+++ b/src/templates/service_nodes.html
@@ -1,44 +1,83 @@
 
 <div class="Wrapper">
     <div class="TitleDivider"></div>
-    <h2 style="margin-bottom: 0px">Service Nodes </h2>
-
-    <h4 class="Subtitle">(No. of Service Nodes: {{service_node_active_size}})</h4>
-    <div class="TitleDivider"></div>
+    <h2 style="margin-bottom: 0px">Service Nodes</h2>
+    <h4 class="Subtitle">(No. of active Service Nodes: {{service_nodes_active_size}})</h4>
+    <div class="TitleDivider sn-active"></div>
 
       <table style="width:100%">
           <tr class="TableHeader">
               <td>Public Key</td>
               <td>Contributors</td>
-              <td>Operator Cut (%)</td>
+              <td>Operator Fee (%)</td>
               <td>Staking Requirement</td>
-              <td>Last Reward At Height</td>
+              <td>Last Reward Height</td>
               <td>Last Uptime Proof</td>
               <td>Expiry Date UTC (Estimated)</td>
           </tr>
 
-          {{#service_node_active_array}}
+          {{#service_nodes_active}}
           <tr>
               <td><a href="/service_node/{{public_key}}">{{public_key}}</a></td>
               <td>{{num_contributors}}</td>
-              <td>{{operator_cut}}</td>
+              <td>{{^solo_node}}{{operator_cut}}{{/solo_node}}</td>
               <td>{{staking_requirement}}</td>
               <td>{{last_reward_at_block}}</td>
               <td>{{last_uptime_proof}}</td>
-              <td>{{expiration_date}} ({{expiration_time_relative}})</td>
+              <td>
+                  {{#expiration_date}}{{expiration_date}} ({{expiration_time_relative}}){{/expiration_date}}
+                  {{^expiration_date}}Staking Infinitely{{/expiration_date}}
+              </td>
           </tr>
-          {{/service_node_active_array}}
+          {{/service_nodes_active}}
+          {{#service_nodes_active_more}}
+          <tr>
+              <td class="sn-more" colspan="7"><a href="/service_nodes">+ {{service_nodes_active_more}} more ↪</a></td>
+          </tr>
+          {{/service_nodes_active_more}}
       </table>
 
-      <h2 style="margin-bottom: 0px">Service Nodes Awaiting</h2>
-      <h4 class="Subtitle">(No. of Service Nodes awaiting contribution: {{service_node_awaiting_size}})</h4>
-      <div class="TitleDivider"></div>
+    <h2 style="margin-bottom: 0px" id="service-nodes-inactive">Inactive/Decommissioned Service Nodes</h2>
+    <h4 class="Subtitle">(These {{service_nodes_inactive_size}} service nodes are currently <span style="font-weight: bold; text-decoration: underline">not earning rewards</span> and face deregistration soon)</h4>
+    <div class="TitleDivider sn-inactive"></div>
 
       <table style="width:100%">
           <tr class="TableHeader">
               <td>Public Key</td>
               <td>Contributors</td>
-              <td>Operator Cut (%)</td>
+              <td>Operator Fee (%)</td>
+              <td>Decommission Height</td>
+              <td>Last Uptime Proof</td>
+              <td>Blocks until Dereg.</td>
+          </tr>
+
+          {{#service_nodes_inactive}}
+          <tr>
+              <td><a href="/service_node/{{public_key}}">{{public_key}}</a></td>
+              <td>{{num_contributors}}</td>
+              <td>{{^solo_node}}{{operator_cut}}{{/solo_node}}</td>
+              <td>{{decommission_height}}</td>
+              <td>{{last_uptime_proof}}</td>
+              <td>{{#credit_remaining}}{{earned_downtime_blocks}} ({{earned_downtime}}){{/credit_remaining}}
+                  {{^credit_remaining}}None (deregistration imminent!){{/credit_remaining}}</td>
+          </tr>
+          {{/service_nodes_inactive}}
+          {{#service_nodes_inactive_more}}
+          <tr>
+              <td class="sn-more" colspan="7"><a href="/service_nodes#service-nodes-inactive">+ {{service_nodes_inactive_more}} more ↪</a></td>
+          </tr>
+          {{/service_nodes_inactive_more}}
+      </table>
+
+      <h2 style="margin-bottom: 0px" id="service-nodes-awaiting">Service Nodes Awaiting</h2>
+      <h4 class="Subtitle">(No. of Service Nodes awaiting contribution: {{service_nodes_awaiting_size}})</h4>
+      <div class="TitleDivider sn-awaiting"></div>
+
+      <table style="width:100%">
+          <tr class="TableHeader">
+              <td>Public Key</td>
+              <td>Contributors</td>
+              <td>Operator Fee (%)</td>
               <td>Open For Contribution</td>
               <td>Contributed</td>
               <td>Reserved</td>
@@ -46,17 +85,26 @@
               <td>Expiry Date UTC (Estimated)</td>
           </tr>
 
-          {{#service_node_awaiting_array}}
+          {{#service_nodes_awaiting}}
           <tr>
               <td><a href="/service_node/{{public_key}}">{{public_key}}</a></td>
               <td>{{num_contributors}}</td>
-              <td>{{operator_cut}}</td>
+              <td>{{^solo_node}}{{operator_cut}}{{/solo_node}}</td>
               <td>{{open_for_contribution}}</td>
-              <td>{{contributed}}</td>
-              <td>{{reserved}}</td>
+              <td>{{total_contributed}}</td>
+              <td>{{total_reserved}}</td>
               <td>{{staking_requirement}}</td>
               <td>{{expiration_date}} ({{expiration_time_relative}})</td>
           </tr>
-          {{/service_node_awaiting_array}}
+          {{/service_nodes_awaiting}}
+          {{#service_nodes_awaiting_more}}
+          <tr>
+              <td class="sn-more" colspan="7"><a href="/service_nodes#service-nodes-awaiting">+ {{service_nodes_awaiting_more}} more ↪</a></td>
+          </tr>
+          {{/service_nodes_awaiting_more}}
       </table>
 </div> <!-- Wrapper -->
+
+<div class="Wrapper">
+    <p> <a class="" href="/service_nodes">click here to see the full service node lists (at most only 10 of each list are shown here)</a> </p>
+</div>

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1341,35 +1341,21 @@ get_human_readable_timestamp(uint64_t ts, std::string *result)
     *result = buf;
 }
 
-
-char const *get_human_time_ago(time_t t, time_t now)
+std::string get_human_timespan(time_t dt)
 {
-    if (t == now)
-      return "now";
+    std::ostringstream ss;
+    if (dt < 90)             ss << dt << " seconds";
+    else if (dt < 90 * 60)   ss << std::setprecision(1) << std::fixed << dt/60. << " minutes";
+    else if (dt < 36 * 3600) ss << std::setprecision(1) << std::fixed << dt/3600. << " hours";
+    else                     ss << std::setprecision(dt < 99.5 * 3600 ? 1 : 0) << std::fixed << dt/86400. << " days";
+    return ss.str();
+}
 
-    static char buf[128];
-    buf[0] = 0;
-
-    char *buf_ptr       = buf;
-    char const *buf_end = buf + sizeof(buf);
-    time_t dt           = t > now ? t - now : now - t;
-
-    if (t > now)
-    {
-      buf_ptr += snprintf(buf_ptr, buf_ptr - buf_end, "in ");
-    }
-
-    if (dt < 90)             buf_ptr += snprintf(buf_ptr, buf_ptr - buf_end, "%zu seconds", dt);
-    else if (dt < 90 * 60)   buf_ptr += snprintf(buf_ptr, buf_ptr - buf_end, "%zu minutes", dt/60);
-    else if (dt < 36 * 3600) buf_ptr += snprintf(buf_ptr, buf_ptr - buf_end, "%zu hours", dt/3600);
-    else                     buf_ptr += snprintf(buf_ptr, buf_ptr - buf_end, "%zu days", dt/(3600*24));
-
-    if (t < now)
-    {
-      buf_ptr += snprintf(buf_ptr, buf_ptr - buf_end, " ago");
-    }
-
-    return buf;
+std::string get_human_time_ago(time_t t, time_t now)
+{
+    if (t == now) return "now";
+    std::string span = get_human_timespan(t > now ? t - now : now - t);
+    return t > now ? "in " + span : span + " ago";
 }
 
 string

--- a/src/tools.h
+++ b/src/tools.h
@@ -379,7 +379,10 @@ bytes_to_hex(char const *bytes, int len);
 void
 get_human_readable_timestamp(uint64_t ts, std::string *result);
 
-char const *
+std::string
+get_human_timespan(time_t dt);
+
+std::string
 get_human_time_ago(time_t t, time_t now);
 
 std::string


### PR DESCRIPTION
Implementation of various new Heimdall-related service node features and
various small user-facing edits/improvements:

- Fixed compilation for moved/renamed/updated loki fields
- Decodes new-style deregistrations + new
  decommission/recommission/ip_change_penalty txes
- Rename "operator cut" to "operator fee" in the templates
- Only show operator fee for non-solo nodes; a fee of "100%" is more of
  an implementation detail than an actual fee.
- Disable ssl on RPC requests (otherwise the explorer ends up generating
  a new SSL key on every single request)
- Rewrite most of the code used to generate service node info; it was
  being added (differently) in multiple places and was missing a bunch
  of things we now need.
- Don't show the "last_reward_at_block_tx_index" value when it equals
  (uint32_t) -1.  This was just an internal implementation detail
  special value that has no relevance for a user.
- Showing "last_reward_at_height" value is similarly pretty confusing:
  while it is sometimes the last reward height, it is also sometimes the
  activation height or the last contribution height, so changed the
  label to indicate this in the display.
- Align the SN metadata values in the display
- Show a link "+ 13 more ↪" at the bottom of the SN lists when they have
  been truncated (rather than having to scroll down to the link at the
  bottom of all of the SN lists).
- some time string values now include a decimal digit (e.g. 7.3
  days) and are rounded instead of truncated.
- Show TX fees in LOKI again (instead of µLOKI) since we've multiplying
  them by 80.
- Fix the `--no-blocks-on-index` to actually do what it says it does (i.e. specifying 10 now gives 10 instead of 11).
-  Add target/voter pubkeys to state change tx info; by default this only works
for quorum states already stored, but with https://github.com/loki-project/loki/pull/702 it can
display old values as well.